### PR TITLE
fix: incorrect removal of v in tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,10 +19,15 @@ main() {
   if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
     REF="${GITHUB_HEAD_REF}"
   fi
-  # Detect if it is a tag
+  # Detect if it is an @ tag
   if [ -z "${REF##*refs/tags*}" ]; then
-    # Remove everything that is before the @ or v tag
-    REF=${REF#*[@v]}
+    # Remove everything that is before the @ tag
+    REF=${REF#*[@]}
+  fi
+  # Detect if it is a version tag
+  if [ -z "${REF##*refs/tags/v*}" ]; then
+    # Remove everything that is before the v tag
+    REF=${REF#*[v]}
   fi
 
   # Remove everything that is before the last /

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,17 +22,17 @@ main() {
   # Detect if it is an @ tag
   if [ -z "${REF##*refs/tags*}" ]; then
     # Remove everything that is before the @ tag
-    REF=${REF#*[@]}
+    REF=${REF##*@}
   fi
   # Detect if it is an @v tag
   if [ -z "${REF##v*}" ]; then
     # Remove everything that is before the @v tag
-    REF=${REF#*[v]}
+    REF=${REF##*v}
   fi
   # Detect if it is a slash version tag
   if [ -z "${REF##*refs/tags/v*}" ]; then
     # Remove everything that is before the v tag
-    REF=${REF#*[v]}
+    REF=${REF##*v}
   fi
 
   # Remove everything that is before the last /

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,12 @@ main() {
     # Remove everything that is before the @ tag
     REF=${REF#*[@]}
   fi
-  # Detect if it is a version tag
+  # Detect if it is an @v tag
+  if [ -z "${REF##v*}" ]; then
+    # Remove everything that is before the @v tag
+    REF=${REF#*[v]}
+  fi
+  # Detect if it is a slash version tag
   if [ -z "${REF##*refs/tags/v*}" ]; then
     # Remove everything that is before the v tag
     REF=${REF#*[v]}

--- a/test.bats
+++ b/test.bats
@@ -119,6 +119,22 @@ teardown() {
 /usr/local/bin/docker logout"
 }
 
+@test "it removes prefix for git tags with @ and v" {
+  export GITHUB_REF='refs/tags/versionedapp@1.0.0'
+
+  run /entrypoint.sh
+
+  expectStdOut "
+::set-output name=sha-tag::12169ed809255604e557a82617264e9c373faca7
+::set-output name=ref-tag::1.0.0"
+
+  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin
+/usr/local/bin/docker build -t my/repository:12169ed809255604e557a82617264e9c373faca7 -t my/repository:1.0.0 .
+/usr/local/bin/docker push my/repository:12169ed809255604e557a82617264e9c373faca7
+/usr/local/bin/docker push my/repository:1.0.0
+/usr/local/bin/docker logout"
+}
+
 @test "it pushes specific Dockerfile to branch" {
   export INPUT_DOCKERFILE='MyDockerFileName'
 

--- a/test.bats
+++ b/test.bats
@@ -119,8 +119,24 @@ teardown() {
 /usr/local/bin/docker logout"
 }
 
-@test "it removes prefix for git tags with @ and v" {
-  export GITHUB_REF='refs/tags/versionedapp@1.0.0'
+@test "it removes prefix for git tags with @v" {
+  export GITHUB_REF='refs/tags/versionedapp@v1.0.0'
+
+  run /entrypoint.sh
+
+  expectStdOut "
+::set-output name=sha-tag::12169ed809255604e557a82617264e9c373faca7
+::set-output name=ref-tag::1.0.0"
+
+  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin
+/usr/local/bin/docker build -t my/repository:12169ed809255604e557a82617264e9c373faca7 -t my/repository:1.0.0 .
+/usr/local/bin/docker push my/repository:12169ed809255604e557a82617264e9c373faca7
+/usr/local/bin/docker push my/repository:1.0.0
+/usr/local/bin/docker logout"
+}
+
+@test "it removes prefix for git tags with slash v" {
+  export GITHUB_REF='refs/tags/v1.0.0'
 
   run /entrypoint.sh
 


### PR DESCRIPTION
Problem: Incorrectly creates tag with a leading `v` e.g.
```
invalid argument "eu.gcr.io/minddoc-192316/core-videochat:ideochat@0.0.2" for "-t, --tag" flag: invalid reference format
```
should be: `eu.gcr.io/minddoc-192316/core-videochat:0.0.2`

This PR adds support for tags with `/v`, `@` and `@v`, e.g. `ref/tags/v0.0.2`, `ref/tags/videochat@0.0.2`, and `ref/tags/videochat@v0.0.2` will all output the following: `eu.gcr.io/minddoc-192316/core-videochat:0.0.2`