### PR TITLE
chore(): fix set-output warnings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,8 +68,8 @@ main() {
   fi
 
   pushImage
-  echo name=sha-tag::"${GITHUB_SHA}" >> $GITHUB_OUTPUT
-  echo name=ref-tag::"${REF}" >> $GITHUB_OUTPUT
+  echo name=sha-tag::"${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+  echo name=ref-tag::"${REF}" >> "$GITHUB_OUTPUT"
 
   docker logout
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,8 +68,8 @@ main() {
   fi
 
   pushImage
-  echo ::set-output name=sha-tag::"${GITHUB_SHA}"
-  echo ::set-output name=ref-tag::"${REF}"
+  echo name=sha-tag::"${GITHUB_SHA}" >> $GITHUB_OUTPUT
+  echo name=ref-tag::"${REF}" >> $GITHUB_OUTPUT
 
   docker logout
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,8 +68,8 @@ main() {
   fi
 
   pushImage
-  echo name=sha-tag::"${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-  echo name=ref-tag::"${REF}" >> "$GITHUB_OUTPUT"
+  echo sha-tag="${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+  echo ref-tag="${REF}" >> "$GITHUB_OUTPUT"
 
   docker logout
 }


### PR DESCRIPTION
an attempt to fix set-output warnings

this actions is being used in moodpath docker build and. publish
<img width="1379" alt="image" src="https://github.com/minddocdev/mou-docker-action/assets/8035149/5b77c580-aae8-4b6b-96c9-46a6dd01f111">
